### PR TITLE
Fix "black screen" on macOS 12.x Monterey

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Johannes E. Schindelin <Johannes.Schindelin@gmx.de>
 Christian Beier <info@christianbeier.net>
 Ryo Ota <nwtgck@nwtgck.org>
 Vadim Zeitlin <vz-github@zeitlins.org>
+Pablo Gil Fernández

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_library(SCREEN_CAPTURE_KIT ScreenCaptureKit REQUIRED)
 find_library(CORE_MEDIA CoreMedia)
 find_library(CORE_VIDEO CoreVideo)
 find_library(FOUNDATION Foundation)
+find_library(IOSURFACE IOSurface)
 
 #
 # Sources
@@ -43,12 +44,17 @@ set(MACOSX_BUNDLE_ICON_FILE icon.icns)
 set_source_files_properties(src/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
 add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SOURCE_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  MACOSX_BUNDLE_GUI_IDENTIFIER "net.libvnc.macvnc"
+  MACOSX_BUNDLE_BUNDLE_NAME "macVNC"
+)
 
 target_link_libraries(${PROJECT_NAME} LibVNCServer::vncserver ${CMAKE_THREAD_LIBS_INIT} ${CARBON_LIBRARY} ${IOKIT_LIBRARY}
   ${SCREEN_CAPTURE_KIT}
   ${CORE_MEDIA}
   ${CORE_VIDEO}
-  ${FOUNDATION})
+  ${FOUNDATION}
+  ${IOSURFACE})
 
 #
 # Install, i.e. finalise bundle

--- a/src/ScreenCapturer.m
+++ b/src/ScreenCapturer.m
@@ -4,6 +4,8 @@
 
 @property (nonatomic, assign) CGDirectDisplayID displayID;
 @property (nonatomic, strong) SCStream *stream;
+@property (nonatomic, assign) BOOL hasReceivedFrames;
+@property (nonatomic, strong) NSTimer *permissionCheckTimer;
 
 // handlers
 @property (nonatomic, copy, nonnull) void (^frameHandler)(CMSampleBufferRef sampleBuffer);
@@ -26,28 +28,40 @@
 }
 
 - (void)startCapture {
+    NSLog(@"[ScreenCapturer] Starting capture for display ID: %d", self.displayID);
+    NSLog(@"[ScreenCapturer] Requesting screen capture permissions...");
+
     [SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent *content, NSError *error) {
         if (error) {
+            NSLog(@"[ScreenCapturer] Error getting shareable content: %@", error);
             self.errorHandler(error);
             return;
         }
+        NSLog(@"[ScreenCapturer] Successfully got shareable content with %lu displays", (unsigned long)content.displays.count);
 
         SCDisplay *display = content.displays[[content.displays indexOfObjectPassingTest:^BOOL(SCDisplay *_Nonnull d, NSUInteger idx, BOOL *_Nonnull stop) {
                     return d.displayID == self.displayID;
                 }]];
 
         if (!display) {
+            NSLog(@"[ScreenCapturer] Display ID %d not found in shareable content", self.displayID);
             NSError *noDisplayError = [NSError errorWithDomain:@"ScreenCapturerErrorDomain"
                                                           code:1
                                                       userInfo:@{NSLocalizedDescriptionKey : @"Display not available for capture"}];
             self.errorHandler(noDisplayError);
             return;
         }
+        size_t pixelWidth = CGDisplayPixelsWide(self.displayID);
+        size_t pixelHeight = CGDisplayPixelsHigh(self.displayID);
+        NSLog(@"[ScreenCapturer] Found display, starting stream with size %dx%d (pixels)", (int)pixelWidth, (int)pixelHeight);
+        if (pixelWidth != display.width || pixelHeight != display.height) {
+            NSLog(@"[ScreenCapturer] Retina/scaled display detected: SCDisplay reports %dx%d points", (int)display.width, (int)display.height);
+        }
 
         SCStreamConfiguration *config = [[SCStreamConfiguration alloc] init];
         // can later be adjusted for server-side scaling
-        config.width = display.width;
-        config.height = display.height;
+        config.width = pixelWidth;
+        config.height = pixelHeight;
         // set max frame rate to 60 FPS
         config.minimumFrameInterval = CMTimeMake(1, 60);
         config.pixelFormat = kCVPixelFormatType_32BGRA;
@@ -67,7 +81,28 @@
 
         [self.stream startCaptureWithCompletionHandler:^(NSError * _Nullable startError) {
             if (startError) {
+                NSLog(@"[ScreenCapturer] Error starting capture: %@", startError);
                 self.errorHandler(startError);
+            } else {
+                NSLog(@"[ScreenCapturer] Capture started successfully");
+
+                // Check for frames after 3 seconds
+                self.permissionCheckTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
+                                                                             repeats:NO
+                                                                               block:^(NSTimer * _Nonnull timer) {
+                    if (!self.hasReceivedFrames) {
+                        NSLog(@"[ScreenCapturer] WARNING: Stream started but no frames received after 3 seconds!");
+                        NSLog(@"[ScreenCapturer] This usually means Screen Recording permission is missing.");
+                        NSLog(@"[ScreenCapturer] Please grant Screen Recording permission in:");
+                        NSLog(@"[ScreenCapturer] System Settings > Privacy & Security > Screen Recording");
+                        fprintf(stderr, "\n*** PERMISSION ERROR ***\n");
+                        fprintf(stderr, "Screen Recording permission is required but not granted.\n");
+                        fprintf(stderr, "Please go to: System Settings > Privacy & Security > Screen Recording\n");
+                        fprintf(stderr, "And enable permission for Terminal (or the app running macVNC).\n");
+                        fprintf(stderr, "Then restart this application.\n");
+                        fprintf(stderr, "************************\n\n");
+                    }
+                }];
             }
         }];
     }];
@@ -97,7 +132,15 @@
 */
 
 - (void)stream:(SCStream *)stream didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer ofType:(SCStreamOutputType)type {
+    static int frameCount = 0;
     if (type == SCStreamOutputTypeScreen) {
+        if (!self.hasReceivedFrames) {
+            self.hasReceivedFrames = YES;
+            NSLog(@"[ScreenCapturer] ✓ SUCCESS: Receiving frames! Screen Recording permission is working.");
+        }
+        if (frameCount++ < 5) {
+            NSLog(@"[ScreenCapturer] Received frame #%d", frameCount);
+        }
         self.frameHandler(sampleBuffer);
     }
 }

--- a/src/mac.m
+++ b/src/mac.m
@@ -29,6 +29,7 @@
 
 #include <Carbon/Carbon.h>
 #include <ScreenCaptureKit/ScreenCaptureKit.h>
+#include <IOSurface/IOSurface.h>
 #include <rfb/rfb.h>
 #include <rfb/keysym.h>
 #include <IOKit/pwr_mgt/IOPMLib.h>
@@ -36,6 +37,7 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #import "ScreenCapturer.h"
 
@@ -71,6 +73,10 @@ static rfbBool initialized            = FALSE;
 static rfbBool dim_time_saved         = FALSE;
 static rfbBool sleep_time_saved       = FALSE;
 
+/* Keep screen capturer alive for the life of the server */
+static ScreenCapturer *screenCapturer = nil;
+/* CGDisplayStream for legacy (Monterey) capture */
+static CGDisplayStreamRef displayStream = NULL;
 /* a dictionary mapping characters to keycodes */
 CFMutableDictionaryRef charKeyMap;
 
@@ -562,8 +568,93 @@ ScreenInit(int argc, char**argv)
   rfbScreen->ptrAddEvent = PtrAddEvent;
   rfbScreen->kbdAddEvent = KbdAddEvent;
 
-  ScreenCapturer *capturer = [[ScreenCapturer alloc] initWithDisplay: displayID
-                                                        frameHandler:^(CMSampleBufferRef sampleBuffer) {
+  /* Check macOS version - use CGDisplayStream for Monterey (12.x), ScreenCaptureKit for 13+ */
+  NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+  BOOL useLegacyCapture = (version.majorVersion < 13);
+
+  if (useLegacyCapture) {
+      NSLog(@"[mac.m] macOS version %ld.%ld detected - using CGDisplayStream (legacy mode)",
+            (long)version.majorVersion, (long)version.minorVersion);
+
+      /* Use CGDisplayStream for Monterey and earlier */
+      dispatch_queue_t dispatchQueue = dispatch_queue_create("libvncserver.examples.mac", NULL);
+
+      displayStream = CGDisplayStreamCreateWithDispatchQueue(displayID,
+                                                                         CGDisplayPixelsWide(displayID),
+                                                                         CGDisplayPixelsHigh(displayID),
+                                                                         'BGRA',
+                                                                         nil,
+                                                                         dispatchQueue,
+                                                                         ^(CGDisplayStreamFrameStatus status,
+                                                                           uint64_t displayTime,
+                                                                           IOSurfaceRef frameSurface,
+                                                                           CGDisplayStreamUpdateRef updateRef) {
+          if (status == kCGDisplayStreamFrameStatusFrameComplete && frameSurface != NULL) {
+              rfbClientIteratorPtr iterator;
+              rfbClientPtr cl;
+              const CGRect *updatedRects;
+              size_t updatedRectsCount;
+              size_t r;
+
+              /* Copy new frame to back buffer */
+              IOSurfaceLock(frameSurface, kIOSurfaceLockReadOnly, NULL);
+
+              memcpy(backBuffer,
+                     IOSurfaceGetBaseAddress(frameSurface),
+                     CGDisplayPixelsWide(displayID) * CGDisplayPixelsHigh(displayID) * 4);
+
+              IOSurfaceUnlock(frameSurface, kIOSurfaceLockReadOnly, NULL);
+
+              /* Lock out client reads */
+              iterator = rfbGetClientIterator(rfbScreen);
+              while((cl = rfbClientIteratorNext(iterator))) {
+                  LOCK(cl->sendMutex);
+              }
+              rfbReleaseClientIterator(iterator);
+
+              /* Swap framebuffers */
+              if (backBuffer == frameBufferOne) {
+                  backBuffer = frameBufferTwo;
+                  rfbScreen->frameBuffer = frameBufferOne;
+              } else {
+                  backBuffer = frameBufferOne;
+                  rfbScreen->frameBuffer = frameBufferTwo;
+              }
+
+              /* Mark modified rects in new framebuffer */
+              updatedRects = CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &updatedRectsCount);
+              for(r = 0; r < updatedRectsCount; ++r) {
+                  rfbMarkRectAsModified(rfbScreen,
+                                       updatedRects[r].origin.x,
+                                       updatedRects[r].origin.y,
+                                       updatedRects[r].origin.x + updatedRects[r].size.width,
+                                       updatedRects[r].origin.y + updatedRects[r].size.height);
+              }
+
+              /* Reenable client reads */
+              iterator = rfbGetClientIterator(rfbScreen);
+              while((cl = rfbClientIteratorNext(iterator))) {
+                  UNLOCK(cl->sendMutex);
+              }
+              rfbReleaseClientIterator(iterator);
+          }
+      });
+
+      CGDisplayStreamStart(displayStream);
+      NSLog(@"[mac.m] CGDisplayStream started successfully");
+
+  } else {
+      NSLog(@"[mac.m] macOS version %ld.%ld detected - using ScreenCaptureKit (modern mode)",
+            (long)version.majorVersion, (long)version.minorVersion);
+
+      /* Use ScreenCaptureKit for Ventura and later */
+      screenCapturer = [[ScreenCapturer alloc] initWithDisplay: displayID
+                                              frameHandler:^(CMSampleBufferRef sampleBuffer) {
+          static int frameHandlerCallCount = 0;
+          if (frameHandlerCallCount++ < 3) {
+              NSLog(@"[mac.m] frameHandler called #%d", frameHandlerCallCount);
+          }
+
           rfbClientIteratorPtr iterator;
           rfbClientPtr cl;
 
@@ -571,14 +662,26 @@ ScreenInit(int argc, char**argv)
              Copy new frame to back buffer.
            */
           CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-          if(!pixelBuffer)
+          if(!pixelBuffer) {
+              NSLog(@"[mac.m] ERROR: pixelBuffer is NULL!");
               return;
+          }
 
           CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 
-          memcpy(backBuffer,
-                 CVPixelBufferGetBaseAddress(pixelBuffer),
-                 CGDisplayPixelsWide(displayID) *  CGDisplayPixelsHigh(displayID) * 4);
+          size_t pixelWidth = CGDisplayPixelsWide(displayID);
+          size_t pixelHeight = CGDisplayPixelsHigh(displayID);
+          size_t dstBytesPerRow = pixelWidth * 4;
+          size_t srcBytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+          uint8_t *dstBase = backBuffer;
+          uint8_t *srcBase = CVPixelBufferGetBaseAddress(pixelBuffer);
+
+          size_t copyBytesPerRow = dstBytesPerRow < srcBytesPerRow ? dstBytesPerRow : srcBytesPerRow;
+          for (size_t row = 0; row < pixelHeight; row++) {
+              memcpy(dstBase + row * dstBytesPerRow,
+                     srcBase + row * srcBytesPerRow,
+                     copyBytesPerRow);
+          }
 
           CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 
@@ -620,7 +723,8 @@ ScreenInit(int argc, char**argv)
           //TODO handle other errors
           exit(EXIT_FAILURE);
       }];
-  [capturer startCapture];
+      [screenCapturer startCapture];
+  }
 
   rfbInitServer(rfbScreen);
 


### PR DESCRIPTION
Hi!

After setting all permissions, macVNC emitted just black frames, this PR fixes that behavior splitting the code for Monterey or newer.

That way macVNC turns compatible with macOS 12 Monterey
=D

Cheers